### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ account.nextChainAddress(0)
 console.log(account.getChainAddress(1))
 // => 1DAi282VN7Ack9o5BqWYkiEsS8Vgx1rLn
 
-console.log(account.getChainAddress(1))
+console.log(account.nextChainAddress(1))
 // => 1CXKM323V3kkrHmZQYPUTftGh9VrAWuAYX
 
 console.log(account.derive('1QEj2WQD9vxTzsGEvnmLpvzeLVrpzyKkGt'))


### PR DESCRIPTION
README shows `account.getChainAddress(1)` being called two times in a row and returning two different addresses. Updating 2nd call to `account.nextChainAddress(1)` to return next address.