### PR TITLE
Use bip32 instead of HDNode where we can

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
-sudo: false
 language: node_js
+
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
-  - "8"
-  - "9"
+  - node
+  - lts/*
+  - 12
+  - 10
+  - 8
+
 matrix:
   include:
-    - node_js: "8"
+    - node_js: "lts/*"
       env: TEST_SUITE=standard
-    - node_js: "8"
+    - node_js: "lts/*"
       env: TEST_SUITE=coverage
+
 env:
   - TEST_SUITE=unit
+
 script: npm run-script $TEST_SUITE

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Compatible with bitcoinjs-lib `^2.0.0` and `^3.0.0`.
 
 #### BIP32 Account
 ``` javascript
-var bitcoin = require('bitcoinjs-lib')
-var bip32utils = require('bip32-utils')
+let bitcoin = require('bitcoinjs-lib')
+let bip32utils = require('bip32-utils')
 
 // ...
 
-var m = bitcoin.HDNode.fromSeedHex(seedHex)
-var i = m.deriveHardened(0)
-var external = i.derive(0)
-var internal = i.derive(1)
-var account = new bip32utils.Account([
+let m = bitcoin.HDNode.fromSeedHex(seedHex)
+let i = m.deriveHardened(0)
+let external = i.derive(0)
+let internal = i.derive(1)
+let account = new bip32utils.Account([
   new bip32utils.Chain(external.neutered()),
   new bip32utils.Chain(internal.neutered())
 ])
@@ -50,17 +50,17 @@ console.log(account.derive('1QEj2WQD9vxTzsGEvnmLpvzeLVrpzyKkGt', [external, inte
 
 #### BIP32 Chains
 ``` javascript
-var bitcoin = require('bitcoinjs-lib')
-var bip32utils = require('bip32-utils')
+let bitcoin = require('bitcoinjs-lib')
+let bip32utils = require('bip32-utils')
 
 // ...
 
-var hdNode = bitcoin.HDNode.fromSeedHex(seedHex)
-var chain = new bip32utils.Chain(hdNode)
+let hdNode = bitcoin.HDNode.fromSeedHex(seedHex)
+let chain = new bip32utils.Chain(hdNode)
 
-for (var k = 0; k < 10; ++k) chain.next()
+for (let k = 0; k < 10; ++k) chain.next()
 
-var address = chain.get()
+let address = chain.get()
 
 console.log(chain.find(address))
 // => 9
@@ -72,22 +72,22 @@ console.log(chain.pop())
 
 #### BIP32 Discovery (manual)
 ``` javascript
-var bip32utils = require('bip32-utils')
-var bitcoin = require('bitcoinjs-lib')
-var Blockchain = require('cb-blockr')
+let bip32utils = require('bip32-utils')
+let bitcoin = require('bitcoinjs-lib')
+let Blockchain = require('cb-blockr')
 
 // ...
 
-var blockchain = new Blockchain('testnet')
-var hdNode = bitcoin.HDNode.fromSeedHex(seedHex)
-var chain = bip32utils.Chain(hdNode)
-var GAP_LIMIT = 20
+let blockchain = new Blockchain('testnet')
+let hdNode = bitcoin.HDNode.fromSeedHex(seedHex)
+let chain = bip32utils.Chain(hdNode)
+let GAP_LIMIT = 20
 
 bip32utils.discovery(chain, GAP_LIMIT, function(addresses, callback) {
   blockchain.addresses.summary(addresses, function(err, results) {
     if (err) return callback(err)
 
-    var areUsed = results.map(function(result) {
+    let areUsed = results.map(function(result) {
       return result.totalReceived > 0
     })
 
@@ -101,8 +101,8 @@ bip32utils.discovery(chain, GAP_LIMIT, function(addresses, callback) {
   console.log('With at least ' + (checked - used) + ' unused addresses')
 
   // throw away ALL unused addresses AFTER the last unused address
-  var unused = checked - used
-  for (var i = 1; i < unused; ++i) chain.pop()
+  let unused = checked - used
+  for (let i = 1; i < unused; ++i) chain.pop()
 
   // remember used !== total, chain may have started at a k-index > 0
   console.log('Total number of addresses (after prune): ', chain.addresses.length)

--- a/account.js
+++ b/account.js
@@ -1,17 +1,17 @@
-var bip32 = require('bip32')
-var discovery = require('./discovery')
+const bip32 = require('bip32')
+const discovery = require('./discovery')
 
-var Chain = require('./chain')
+const Chain = require('./chain')
 
 function Account (chains) {
   this.chains = chains
 }
 
 Account.fromJSON = function (json, network, addressFunction) {
-  var chains = json.map(function (j) {
-    var node = bip32.fromBase58(j.node, network)
+  const chains = json.map(function (j) {
+    const node = bip32.fromBase58(j.node, network)
 
-    var chain = new Chain(node, j.k, addressFunction)
+    const chain = new Chain(node, j.k, addressFunction)
     chain.map = j.map
 
     // derive from k map
@@ -39,7 +39,7 @@ Account.prototype.containsAddress = function (address) {
 
 // optional parents argument for private key escalation
 Account.prototype.derive = function (address, parents) {
-  var derived
+  let derived
 
   this.chains.some(function (chain, i) {
     derived = chain.derive(address, parents && parents[i])
@@ -50,15 +50,15 @@ Account.prototype.derive = function (address, parents) {
 }
 
 Account.prototype.discoverChain = function (i, gapLimit, queryCallback, callback) {
-  var chains = this.chains
-  var chain = chains[i].clone()
+  const chains = this.chains
+  const chain = chains[i].clone()
 
   discovery(chain, gapLimit, queryCallback, function (err, used, checked) {
     if (err) return callback(err)
 
     // throw away EACH unused address AFTER the last unused address
-    var unused = checked - used
-    for (var j = 1; j < unused; ++j) chain.pop()
+    const unused = checked - used
+    for (let j = 1; j < unused; ++j) chain.pop()
 
     // override the internal chain
     chains[i] = chain

--- a/account.js
+++ b/account.js
@@ -1,4 +1,4 @@
-var bitcoinjs = require('bitcoinjs-lib')
+var bip32 = require('bip32')
 var discovery = require('./discovery')
 
 var Chain = require('./chain')
@@ -9,7 +9,7 @@ function Account (chains) {
 
 Account.fromJSON = function (json, network, addressFunction) {
   var chains = json.map(function (j) {
-    var node = bitcoinjs.HDNode.fromBase58(j.node, network)
+    var node = bip32.fromBase58(j.node, network)
 
     var chain = new Chain(node, j.k, addressFunction)
     chain.map = j.map
@@ -76,7 +76,7 @@ Account.prototype.getAllAddresses = function () {
 Account.prototype.getChain = function (i) { return this.chains[i] }
 Account.prototype.getChains = function () { return this.chains }
 Account.prototype.getChainAddress = function (i) { return this.chains[i].get() }
-Account.prototype.getNetwork = function () { return this.chains[0].getParent().keyPair.network }
+Account.prototype.getNetwork = function () { return this.chains[0].getParent().network }
 
 Account.prototype.isChainAddress = function (i, address) {
   return this.chains[i].find(address) !== undefined

--- a/chain.js
+++ b/chain.js
@@ -1,6 +1,6 @@
-var Buffer = require('safe-buffer').Buffer
-var createHash = require('create-hash')
-var bs58check = require('bs58check')
+const Buffer = require('safe-buffer').Buffer
+const createHash = require('create-hash')
+const bs58check = require('bs58check')
 
 function ripemd160 (buffer) {
   return createHash('rmd160').update(buffer).digest()
@@ -15,7 +15,7 @@ function hash160 (buffer) {
 }
 
 function toBase58Check (hash, version) {
-  var payload = Buffer.allocUnsafe(21)
+  const payload = Buffer.allocUnsafe(21)
   payload.writeUInt8(version, 0)
   hash.copy(payload, 1)
 
@@ -37,22 +37,22 @@ function Chain (parent, k, addressFunction) {
 }
 
 Chain.prototype.__initialize = function () {
-  var address = this.addressFunction(this.__parent.derive(this.k), this.__parent.network)
+  const address = this.addressFunction(this.__parent.derive(this.k), this.__parent.network)
   this.map[address] = this.k
   this.addresses.push(address)
 }
 
 Chain.prototype.clone = function () {
-  var chain = new Chain(this.__parent, this.k, this.addressFunction)
+  const chain = new Chain(this.__parent, this.k, this.addressFunction)
 
   chain.addresses = this.addresses.concat()
-  for (var s in this.map) chain.map[s] = this.map[s]
+  for (const s in this.map) chain.map[s] = this.map[s]
 
   return chain
 }
 
 Chain.prototype.derive = function (address, parent) {
-  var k = this.map[address]
+  const k = this.map[address]
   if (k === undefined) return
 
   parent = parent || this.__parent
@@ -81,7 +81,7 @@ Chain.prototype.getParent = function () {
 
 Chain.prototype.next = function () {
   if (this.addresses.length === 0) this.__initialize()
-  var address = this.addressFunction(this.__parent.derive(this.k + 1), this.__parent.network)
+  const address = this.addressFunction(this.__parent.derive(this.k + 1), this.__parent.network)
 
   this.k += 1
   this.map[address] = this.k
@@ -91,7 +91,7 @@ Chain.prototype.next = function () {
 }
 
 Chain.prototype.pop = function () {
-  var address = this.addresses.pop()
+  const address = this.addresses.pop()
   delete this.map[address]
   this.k -= 1
 

--- a/discovery.js
+++ b/discovery.js
@@ -1,10 +1,10 @@
 // https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery
 module.exports = function discovery (chain, gapLimit, queryCb, done) {
-  var gap = 0
-  var checked = 0
+  let gap = 0
+  let checked = 0
 
   function cycle () {
-    var batch = [chain.get()]
+    const batch = [chain.get()]
     checked++
 
     while (batch.length < gapLimit) {
@@ -28,7 +28,7 @@ module.exports = function discovery (chain, gapLimit, queryCb, done) {
       })
 
       if (gap >= gapLimit) {
-        var used = checked - gap
+        const used = checked - gap
 
         return done(undefined, used, checked)
       } else {

--- a/package.json
+++ b/package.json
@@ -28,23 +28,24 @@
     "coverage-report": "nyc report --reporter=lcov",
     "coverage": "nyc --check-coverage --branches 90 --functions 90 npm run unit",
     "standard": "standard",
+    "standard-fix": "standard --fix",
     "test": "npm run standard && npm run coverage",
     "unit": "tape test/*.js"
   },
   "devDependencies": {
-    "bitcoinjs-lib": "^3.3.2",
-    "keccak": "^1.3.0",
-    "nyc": "*",
-    "standard": "*",
-    "tape": "*"
+    "bitcoinjs-lib": "^5.1.7",
+    "keccak": "^3.0.0",
+    "nyc": "^15.0.0",
+    "standard": "^14.3.1",
+    "tape": "^4.13.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
-    "bip32": "^0.1.0",
-    "bs58check": "^2.1.1",
+    "bip32": "^2.0.5",
+    "bs58check": "^2.1.2",
     "create-hash": "^1.2.0",
-    "safe-buffer": "^5.1.2"
+    "safe-buffer": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,16 +32,19 @@
     "unit": "tape test/*.js"
   },
   "devDependencies": {
-    "bitcoinjs-lib": "^3.0.0",
+    "bitcoinjs-lib": "^3.3.2",
     "keccak": "^1.3.0",
     "nyc": "*",
     "standard": "*",
     "tape": "*"
   },
-  "peerDependencies": {
-    "bitcoinjs-lib": "^3.0.0"
-  },
   "engines": {
     "node": ">=4.0.0"
+  },
+  "dependencies": {
+    "bip32": "^0.1.0",
+    "bs58check": "^2.1.1",
+    "create-hash": "^1.2.0",
+    "safe-buffer": "^5.1.2"
   }
 }

--- a/test/account.js
+++ b/test/account.js
@@ -1,13 +1,13 @@
-var Account = require('../account')
-var Chain = require('../chain')
-var test = require('tape')
+const Account = require('../account')
+const Chain = require('../chain')
+const test = require('tape')
 
-var f = require('./fixtures/account')
+const f = require('./fixtures/account')
 f.allAddresses = [].concat.apply([], f.addresses)
 
 function blankAccount (json) {
-  var account = Account.fromJSON(json)
-  var chains = account.chains.map(function (chain) {
+  const account = Account.fromJSON(json)
+  const chains = account.chains.map(function (chain) {
     return new Chain(chain.__parent, 0)
   })
 
@@ -15,7 +15,7 @@ function blankAccount (json) {
 }
 
 test('containsAddress', function (t) {
-  var account = Account.fromJSON(f.neutered.json)
+  const account = Account.fromJSON(f.neutered.json)
 
   f.allAddresses.forEach(function (address) {
     t.equal(account.containsAddress(address), true, 'returns true for known chain address')
@@ -26,14 +26,14 @@ test('containsAddress', function (t) {
 })
 
 test('clone', function (t) {
-  var account = Account.fromJSON(f.neutered.json)
-  var clone = account.clone()
+  const account = Account.fromJSON(f.neutered.json)
+  const clone = account.clone()
 
   // by reference
   t.equal(account.chains.length, clone.chains.length, 'same number of chains')
   t.notEqual(account.chains, clone.chains, 'chain arrays are different arrays')
   t.same(account.chains, clone.chains, 'chains are deep copied')
-  for (var i = 0; i < account.chains.length; ++i) {
+  for (let i = 0; i < account.chains.length; ++i) {
     t.notEqual(account.chains[i], clone.chains[i], 'chains are different objects')
   }
 
@@ -43,23 +43,23 @@ test('clone', function (t) {
 })
 
 test('discoverChain', function (t) {
-  var account = Account.fromJSON(f.neutered.json)
-  var before = account.getChainAddress(0)
-  var after = account.getChain(0).clone().next()
+  const account = Account.fromJSON(f.neutered.json)
+  const before = account.getChainAddress(0)
+  const after = account.getChain(0).clone().next()
 
   t.test('does not mutate the chain during discovery', function (t) {
     t.plan(2)
 
     account.discoverChain(0, 20, function (addresses, callback) {
-      var tmpAddrs = addresses.map(function (address) {
+      const tmpAddrs = addresses.map(function (address) {
         // account.containsAddress would return true if internally the chain was iterating
         return address !== before && account.containsAddress(address)
       })
 
-      var addrs = {}
+      const addrs = {}
 
-      for (var add in tmpAddrs) {
-        addrs[add] = tmpAddrs[add]
+      for (const add in tmpAddrs) {
+        addrs[addresses[add]] = tmpAddrs[add]
       }
 
       return callback(null, addrs)
@@ -73,15 +73,15 @@ test('discoverChain', function (t) {
     t.plan(2)
 
     account.discoverChain(0, 20, function (addresses, callback) {
-      var tmpAddrs = addresses.map(function (address) {
+      const tmpAddrs = addresses.map(function (address) {
         // account.containsAddress would return true if internally the chain was iterating
         return account.containsAddress(address)
       })
 
-      var addrs = {}
+      const addrs = {}
 
-      for (var add in tmpAddrs) {
-        addrs[add] = tmpAddrs[add]
+      for (const add in tmpAddrs) {
+        addrs[addresses[add]] = tmpAddrs[add]
       }
 
       return callback(null, addrs)
@@ -93,21 +93,21 @@ test('discoverChain', function (t) {
 })
 
 test('getAllAddresses', function (t) {
-  var account = blankAccount(f.neutered.json)
+  const account = blankAccount(f.neutered.json)
 
   t.plan(2)
   t.equal(account.getAllAddresses().length, 2, 'returns only 2 addresses post-construction')
 
   // iterate the chains
   f.addresses.forEach(function (a, i) {
-    for (var j = 1; j < a.length; ++j) account.nextChainAddress(i)
+    for (let j = 1; j < a.length; ++j) account.nextChainAddress(i)
   })
 
   t.same(account.getAllAddresses(), f.allAddresses, 'returns all derived addresses')
 })
 
 test('getChainAddress', function (t) {
-  var account = blankAccount(f.neutered.json)
+  const account = blankAccount(f.neutered.json)
 
   f.addresses.forEach(function (addresses, i) {
     addresses.forEach(function (address) {
@@ -120,14 +120,14 @@ test('getChainAddress', function (t) {
 })
 
 test('getNetwork', function (t) {
-  var account = Account.fromJSON(f.neutered.json)
+  const account = Account.fromJSON(f.neutered.json)
 
   t.plan(1)
   t.equal(account.getNetwork(), account.chains[0].__parent.network, 'matches keyPair network')
 })
 
 test('isChainAddress', function (t) {
-  var account = Account.fromJSON(f.neutered.json)
+  const account = Account.fromJSON(f.neutered.json)
 
   f.addresses.forEach(function (addresses, i) {
     addresses.forEach(function (address) {
@@ -140,7 +140,7 @@ test('isChainAddress', function (t) {
 })
 
 test('nextChainAddress', function (t) {
-  var account = blankAccount(f.neutered.json)
+  const account = blankAccount(f.neutered.json)
 
   // returns the new address
   f.addresses.forEach(function (addresses, i) {
@@ -155,7 +155,7 @@ test('nextChainAddress', function (t) {
 })
 
 test('getChain', function (t) {
-  var account = blankAccount(f.neutered.json)
+  const account = blankAccount(f.neutered.json)
 
   f.neutered.json.forEach(function (_, i) {
     t.equal(typeof account.getChain(i), 'object')
@@ -166,7 +166,7 @@ test('getChain', function (t) {
 })
 
 test('getChains', function (t) {
-  var account = blankAccount(f.neutered.json)
+  const account = blankAccount(f.neutered.json)
 
   t.plan(2)
   t.equal(account.getChains().length, f.neutered.json.length, 'returns the expected number of chains')
@@ -174,38 +174,38 @@ test('getChains', function (t) {
 })
 
 test('derive', function (t) {
-  var neutered = Account.fromJSON(f.neutered.json)
+  const neutered = Account.fromJSON(f.neutered.json)
 
   t.test('neutered node', function (t) {
     f.addresses.forEach(function (addresses, i) {
       addresses.forEach(function (address, j) {
-        var actual = neutered.derive(address)
-        var expected = f.neutered.children[i][j]
+        const actual = neutered.derive(address)
+        const expected = f.neutered.children[i][j]
 
         t.equal(expected, actual.toBase58(), 'return a neutered node')
       })
     })
 
-    var unknown = neutered.derive('mpFZW4A9QtRuSpuh9SmeW7RSzFE3TgB8Ko')
+    const unknown = neutered.derive('mpFZW4A9QtRuSpuh9SmeW7RSzFE3TgB8Ko')
     t.equal(undefined, unknown, 'ignores unknown addresses')
     t.end()
   })
 
-  var priv = Account.fromJSON(f.private.json)
+  const priv = Account.fromJSON(f.private.json)
 
   t.test('neutered node w/ escalation', function (t) {
-    var privParents = priv.chains.map(function (x) { return x.__parent })
+    const privParents = priv.chains.map(function (x) { return x.__parent })
 
     f.addresses.forEach(function (addresses, i) {
       addresses.forEach(function (address, j) {
-        var actual = neutered.derive(address, privParents)
-        var expected = f.private.children[i][j]
+        const actual = neutered.derive(address, privParents)
+        const expected = f.private.children[i][j]
 
         t.equal(expected, actual.toBase58(), 'returns a private node')
       })
     })
 
-    var unknown = neutered.derive('mpFZW4A9QtRuSpuh9SmeW7RSzFE3TgB8Ko')
+    const unknown = neutered.derive('mpFZW4A9QtRuSpuh9SmeW7RSzFE3TgB8Ko')
     t.equal(undefined, unknown, 'ignores unknown addresses')
     t.end()
   })
@@ -213,14 +213,14 @@ test('derive', function (t) {
   t.test('private node', function (t) {
     f.addresses.forEach(function (addresses, i) {
       addresses.forEach(function (address, j) {
-        var actual = priv.derive(address)
-        var expected = f.private.children[i][j]
+        const actual = priv.derive(address)
+        const expected = f.private.children[i][j]
 
         t.equal(expected, actual.toBase58(), 'returns a private node')
       })
     })
 
-    var unknown = neutered.derive('mpFZW4A9QtRuSpuh9SmeW7RSzFE3TgB8Ko')
+    const unknown = neutered.derive('mpFZW4A9QtRuSpuh9SmeW7RSzFE3TgB8Ko')
     t.equal(undefined, unknown, 'ignores unknown addresses')
     t.end()
   })
@@ -236,8 +236,8 @@ test('discoverChain', function (t) {
 })
 
 test('toJSON', function (t) {
-  var neutered = Account.fromJSON(f.neutered.json)
-  var priv = Account.fromJSON(f.private.json)
+  const neutered = Account.fromJSON(f.neutered.json)
+  const priv = Account.fromJSON(f.private.json)
 
   t.plan(2)
   t.same(neutered.toJSON(), f.neutered.json, 'neutered json matches fixtures')

--- a/test/account.js
+++ b/test/account.js
@@ -51,10 +51,18 @@ test('discoverChain', function (t) {
     t.plan(2)
 
     account.discoverChain(0, 20, function (addresses, callback) {
-      return callback(null, addresses.map(function (address) {
+      var tmpAddrs = addresses.map(function (address) {
         // account.containsAddress would return true if internally the chain was iterating
         return address !== before && account.containsAddress(address)
-      }))
+      })
+
+      var addrs = {}
+
+      for (var add in tmpAddrs) {
+        addrs[add] = tmpAddrs[add]
+      }
+
+      return callback(null, addrs)
     }, function (err) {
       t.ifErr(err, 'no error')
       t.equal(account.getChainAddress(0), before, 'internal chain was unchanged')
@@ -65,9 +73,18 @@ test('discoverChain', function (t) {
     t.plan(2)
 
     account.discoverChain(0, 20, function (addresses, callback) {
-      return callback(null, addresses.map(function (address) {
+      var tmpAddrs = addresses.map(function (address) {
+        // account.containsAddress would return true if internally the chain was iterating
         return account.containsAddress(address)
-      }))
+      })
+
+      var addrs = {}
+
+      for (var add in tmpAddrs) {
+        addrs[add] = tmpAddrs[add]
+      }
+
+      return callback(null, addrs)
     }, function (err) {
       t.ifErr(err, 'no error')
       t.equal(account.getChainAddress(0), after, 'internal chain iterated forward one address')
@@ -106,7 +123,7 @@ test('getNetwork', function (t) {
   var account = Account.fromJSON(f.neutered.json)
 
   t.plan(1)
-  t.equal(account.getNetwork(), account.chains[0].__parent.keyPair.network, 'matches keyPair network')
+  t.equal(account.getNetwork(), account.chains[0].__parent.network, 'matches keyPair network')
 })
 
 test('isChainAddress', function (t) {

--- a/test/chain.js
+++ b/test/chain.js
@@ -1,14 +1,16 @@
-var bitcoin = require('bitcoinjs-lib')
-var bip32 = require('bip32')
-var Chain = require('../chain')
-var test = require('tape')
-var fixtures = require('./fixtures/chain')
-var createKeccakHash = require('keccak')
+const bitcoin = require('bitcoinjs-lib')
+const bip32 = require('bip32')
+const Chain = require('../chain')
+const test = require('tape')
+const fixtures = require('./fixtures/chain')
+const createKeccakHash = require('keccak')
 
 function segwitAddr (node) {
-  var hash = bitcoin.crypto.hash160(node.publicKey)
-  var script = bitcoin.script.witnessPubKeyHash.output.encode(hash)
-  return bitcoin.address.fromOutputScript(script)
+  const p2wpkh = bitcoin.payments.p2wpkh({
+    pubkey: node.publicKey,
+    network: bitcoin.networks.bitcoin
+  })
+  return p2wpkh.address
 }
 
 function ethAddr (node) {
@@ -17,17 +19,17 @@ function ethAddr (node) {
     .digest().toString('hex')
 }
 
-var AF_MAPPING = {
-  'eth': ethAddr,
-  'segwit': segwitAddr
+const AF_MAPPING = {
+  eth: ethAddr,
+  segwit: segwitAddr
 }
 
 fixtures.forEach(function (f) {
-  var node = bip32.fromBase58(f.node)
-  var addressFunction = AF_MAPPING[f.addressFunction]
+  const node = bip32.fromBase58(f.node)
+  const addressFunction = AF_MAPPING[f.addressFunction]
 
   test('constructor', function (t) {
-    var chain = new Chain(node, null, addressFunction)
+    let chain = new Chain(node, null, addressFunction)
 
     t.plan(3)
     t.equal(chain.k, 0, 'defaults to k=0')
@@ -40,8 +42,8 @@ fixtures.forEach(function (f) {
   })
 
   test('clone', function (t) {
-    var chain = new Chain(node, null, addressFunction)
-    var clone = chain.clone()
+    const chain = new Chain(node, null, addressFunction)
+    let clone = chain.clone()
 
     t.plan(17)
 
@@ -56,7 +58,7 @@ fixtures.forEach(function (f) {
     t.same(chain.map, clone.map, 'k map is deep copied')
     t.same(chain.addressFunction, clone.addressFunction, 'address function is copied')
 
-    for (var i = 0; i < 7; ++i) chain.next()
+    for (let i = 0; i < 7; ++i) chain.next()
     t.equal(clone.k, 0, 'k unchanged by mutation')
     t.notEqual(chain.k, clone.k, 'k unchanged by mutation (2)')
     t.notSame(chain.addresses, clone.addresses, 'address array unchanged by mutation')
@@ -75,12 +77,12 @@ fixtures.forEach(function (f) {
   })
 
   test('find/derive', function (t) {
-    var neutered = node.neutered()
-    var chain = new Chain(neutered, f.k, addressFunction)
+    const neutered = node.neutered()
+    const chain = new Chain(neutered, f.k, addressFunction)
 
     t.plan(30)
-    for (var i = 0; i < 10; ++i) {
-      var address = chain.get()
+    for (let i = 0; i < 10; ++i) {
+      const address = chain.get()
 
       t.equal(chain.find(address), f.k + i)
       t.same(chain.derive(address), neutered.derive(f.k + i))
@@ -90,7 +92,7 @@ fixtures.forEach(function (f) {
   })
 
   test('get', function (t) {
-    var chain = new Chain(node, f.k, addressFunction)
+    const chain = new Chain(node, f.k, addressFunction)
     chain.addresses = f.addresses
 
     t.plan(1)
@@ -98,7 +100,7 @@ fixtures.forEach(function (f) {
   })
 
   test('next', function (t) {
-    var chain = new Chain(node, f.k - f.addresses.length + 1, addressFunction)
+    const chain = new Chain(node, f.k - f.addresses.length + 1, addressFunction)
 
     t.plan(f.addresses.length * 2 + 1)
     f.addresses.forEach(function (x, i) {
@@ -114,10 +116,10 @@ fixtures.forEach(function (f) {
   })
 
   test('pop', function (t) {
-    var chain = new Chain(node, null, addressFunction)
+    const chain = new Chain(node, null, addressFunction)
     chain.next()
     chain.next()
-    var addresses = chain.getAll().concat()
+    const addresses = chain.getAll().concat()
 
     t.plan(8)
     t.equal(chain.getAll().length, 3, 'has 3 addresses')

--- a/test/chain.js
+++ b/test/chain.js
@@ -1,18 +1,19 @@
 var bitcoin = require('bitcoinjs-lib')
+var bip32 = require('bip32')
 var Chain = require('../chain')
 var test = require('tape')
 var fixtures = require('./fixtures/chain')
 var createKeccakHash = require('keccak')
 
 function segwitAddr (node) {
-  var hash = bitcoin.crypto.hash160(node.getPublicKeyBuffer())
+  var hash = bitcoin.crypto.hash160(node.publicKey)
   var script = bitcoin.script.witnessPubKeyHash.output.encode(hash)
   return bitcoin.address.fromOutputScript(script)
 }
 
 function ethAddr (node) {
   return '0x' + createKeccakHash('keccak256')
-    .update(node.getPublicKeyBuffer())
+    .update(node.publicKey)
     .digest().toString('hex')
 }
 
@@ -22,7 +23,7 @@ var AF_MAPPING = {
 }
 
 fixtures.forEach(function (f) {
-  var node = bitcoin.HDNode.fromBase58(f.node)
+  var node = bip32.fromBase58(f.node)
   var addressFunction = AF_MAPPING[f.addressFunction]
 
   test('constructor', function (t) {

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -1,15 +1,15 @@
-var bitcoinjs = require('bitcoinjs-lib')
-var bip32 = require('bip32')
-var Chain = require('../chain')
-var discovery = require('../discovery')
-var test = require('tape')
+const bitcoinjs = require('bitcoinjs-lib')
+const bip32 = require('bip32')
+const Chain = require('../chain')
+const discovery = require('../discovery')
+const test = require('tape')
 
-var fixtures = require('./fixtures/discovery')
+const fixtures = require('./fixtures/discovery')
 
 fixtures.valid.forEach(function (f) {
-  var network = bitcoinjs.networks[f.network]
-  var external = bip32.fromBase58(f.external, network)
-  var chain = new Chain(external, f.k)
+  const network = bitcoinjs.networks[f.network]
+  const external = bip32.fromBase58(f.external, network)
+  const chain = new Chain(external, f.k)
 
   test('discovers until ' + f.expected.used + ' for ' + f.description + ' (GAP_LIMIT = ' + f.gapLimit + ')', function (t) {
     discovery(chain, f.gapLimit, function (addresses, callback) {
@@ -20,15 +20,15 @@ fixtures.valid.forEach(function (f) {
       t.equal(used, f.expected.used, 'used as expected')
       t.equal(checked, f.expected.checked, 'checked count as expected')
 
-      var unused = checked - used
-      for (var i = 1; i < unused; ++i) chain.pop()
+      const unused = checked - used
+      for (let i = 1; i < unused; ++i) chain.pop()
 
       t.equal(chain.get(), f.expected.nextToUse, 'next address to use matches')
     })
   })
 
   test('discover calls done on error', function (t) {
-    var _err = new Error('e')
+    const _err = new Error('e')
 
     discovery(chain, f.gapLimit, function (addresses, callback) {
       return callback(_err)

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -1,4 +1,5 @@
 var bitcoinjs = require('bitcoinjs-lib')
+var bip32 = require('bip32')
 var Chain = require('../chain')
 var discovery = require('../discovery')
 var test = require('tape')
@@ -7,7 +8,7 @@ var fixtures = require('./fixtures/discovery')
 
 fixtures.valid.forEach(function (f) {
   var network = bitcoinjs.networks[f.network]
-  var external = bitcoinjs.HDNode.fromBase58(f.external, network)
+  var external = bip32.fromBase58(f.external, network)
   var chain = new Chain(external, f.k)
 
   test('discovers until ' + f.expected.used + ' for ' + f.description + ' (GAP_LIMIT = ' + f.gapLimit + ')', function (t) {


### PR DESCRIPTION
[HDNodes have been removed from `bitcoinjs-lib`](https://github.com/bitcoinjs/bitcoinjs-lib/commit/884f3fd57d910637c7ae8ea8219d261571458cd9) in favor of using the `bip32` package, thus, it also made sense to move `bip32-utils` over to `bip32` as well.

In addition to HDNodes being removed, the [`getAddress` function on ECPair](https://github.com/bitcoinjs/bitcoinjs-lib/commit/c2a5d9dc1aa98545e47abe3fb0bd22d6b0c5e61d#diff-96082743fb1de06f04b14340e4f00bee) has been removed. The DEFAULT_ADDRESS_FUNCTION has been updated in order to generate a Base58 address.

I have fixed most of the tests, but there is still one test that fails (`23 internal chain iterated forward one address`)

Let me know if you have any questions, or need more changes made.